### PR TITLE
Fix bug that locks the carousel when the user resizes the screen

### DIFF
--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -102,7 +102,7 @@ const Carousel = ({
   const [activeItem, setActiveItem] = useState(0)
   const [touchPosition, setTouchPosition] = useState<number | null>(null)
   const { width } = useWindowSize()
-  
+
   // When the highlight option is active the carousel will transition the slides
   // and count the limit in a different manner
   const LENGTH = Children.toArray(children).length
@@ -111,7 +111,7 @@ const Carousel = ({
   const SHOW_RIGHT_ARROW = show !== LENGTH && activeItem < LIMIT
 
   // Every time the user resizes his window, the carousel sets itself to
-  // the first item 
+  // the first item
   useEffect(() => {
     setActiveItem(0)
   }, [width])

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -3,11 +3,13 @@ import {
   Children,
   CSSProperties,
   useState,
+  useEffect,
   TouchEvent,
   cloneElement,
   ReactElement,
 } from "react"
 import { HiOutlineChevronLeft, HiOutlineChevronRight } from "react-icons/hi"
+import useWindowSize from "../../hooks/useWindowSize"
 
 interface CarouselProps {
   children: ReactNode
@@ -99,13 +101,20 @@ const Carousel = ({
 }: CarouselProps) => {
   const [activeItem, setActiveItem] = useState(0)
   const [touchPosition, setTouchPosition] = useState<number | null>(null)
-
+  const { width } = useWindowSize()
+  
   // When the highlight option is active the carousel will transition the slides
   // and count the limit in a different manner
   const LENGTH = Children.toArray(children).length
   const LIMIT = LENGTH - (highlight ? 1 : show)
   const SHOW_LEFT_ARROW = show !== LENGTH && activeItem !== 0
   const SHOW_RIGHT_ARROW = show !== LENGTH && activeItem < LIMIT
+
+  // Every time the user resizes his window, the carousel sets itself to
+  // the first item 
+  useEffect(() => {
+    setActiveItem(0)
+  }, [width])
 
   const moveToNext = () => {
     if (activeItem >= LIMIT) return


### PR DESCRIPTION
# Description

Eu adicionei um useEffect que checa a  cada renderização do componente se a janela do usuário disparou o event "resize".
Quando isso ocorre, o carrossel é automaticamente resetado para a primeira posição, assim evitando o bug de travamento.

Closes #53 

## Tipo de mudança

- [x] Bug fix (mudança não críticaque conserta uma issue)
- [ ] New feature (mudança não crítica que adiciona uma nova feature)
- [ ] Mudança crítica (Concerto ou uma feature que pode quebrar funcionalidades antigas)
- [ ] Apenas mudança de documentação

# Checklist:

- [x] Realizei uma revisão do meu código
- [x] Eu comentei meus códigos, particularmente nas aŕeas mais difíceis
- [ ] Eu fiz as mudanças correspondentes na documentação
- [x] Minhas mudanças não geraram nenhum warning
- [x] Qualquer mudança pendente na main branch já foi implementada nessa branch
